### PR TITLE
Error: Invalid encoding UTF8

### DIFF
--- a/lib/pt/data_row.rb
+++ b/lib/pt/data_row.rb
@@ -11,7 +11,7 @@ class PT::DataRow
 
   def method_missing(method)
     str = @record.send(method).to_s
-    str.respond_to?(:force_encoding) ? str.force_encoding('utf-8') : Iconv.iconv('UTF8', 'UTF8', str)
+    str.respond_to?(:force_encoding) ? str.force_encoding('utf-8') : Iconv.iconv('UTF-8', 'UTF-8', str)
   end
 
   def to_s


### PR DESCRIPTION
Fix for the following error which occurred when I ran "pt" to set up my config:

I can't find info about this project in /Users/johanandersson/github/Applications/.pt
/opt/local/lib/ruby/gems/1.8/gems/pt-0.3.7/lib/pt/data_row.rb:14:in `iconv': invalid encoding ("UTF8", "UTF8") (Iconv::InvalidEncoding)
    from /opt/local/lib/ruby/gems/1.8/gems/pt-0.3.7/lib/pt/data_row.rb:14:in`method_missing'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/helpers/object_table.rb:10:in `__send__'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/helpers/object_table.rb:10:in`render'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/util.rb:12:in `inject'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/helpers/object_table.rb:10:in`each'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/helpers/object_table.rb:10:in `inject'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/helpers/object_table.rb:10:in`render'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/util.rb:12:in `inject'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/helpers/object_table.rb:9:in`each'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/helpers/object_table.rb:9:in `inject'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/helpers/object_table.rb:9:in`render'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/helpers/auto_table.rb:22:in `render'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/formatter.rb:73:in`_format_output'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/formatter.rb:56:in `format_output'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/view.rb:204:in`render_output'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/console.rb:18:in `render_output'
    from /opt/local/lib/ruby/gems/1.8/gems/hirb-0.5.0/lib/hirb/console.rb:30:in`table'
    from /opt/local/lib/ruby/gems/1.8/gems/pt-0.3.7/lib/pt/data_table.rb:17:in `print'
    from /opt/local/lib/ruby/gems/1.8/gems/pt-0.3.7/lib/pt/ui.rb:271:in`select'
    from /opt/local/lib/ruby/gems/1.8/gems/pt-0.3.7/lib/pt/ui.rb:222:in `load_local_config'
    from /opt/local/lib/ruby/gems/1.8/gems/pt-0.3.7/lib/pt/ui.rb:15:in`initialize'
    from /opt/local/lib/ruby/gems/1.8/gems/pt-0.3.7/bin/pt:8:in `new'
    from /opt/local/lib/ruby/gems/1.8/gems/pt-0.3.7/bin/pt:8
    from /opt/local/bin/pt:19:in`load'
    from /opt/local/bin/pt:19
