### PR TITLE
Fixed "create" when not passing in optional parameters

### DIFF
--- a/lib/pt/ui.rb
+++ b/lib/pt/ui.rb
@@ -557,10 +557,10 @@ class PT::UI
   def find_owner query    
     members = @client.get_members(@project)
     members.each do | member |
-      if member.name.downcase.index query
+      if member.name.downcase.index query.to_s
         return member
       end
-      if member.initials.downcase.index query
+      if member.initials.downcase.index query.to_s
         return member
       end
     end


### PR DESCRIPTION
When @params[1] and [2] aren't specified, String.index threw a type error. 

This tool is really great and your code is super clean, kudos. 
