### PR TITLE
Fix running bin/pt from repo

### DIFF
--- a/bin/pt
+++ b/bin/pt
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 
-lib = File.expand_path(File.dirname(__FILE__) + '/../lib')
+require 'pathname'
+
+lib = (Pathname.new(__FILE__).realpath.dirname  + '../lib').to_s
 $LOAD_PATH.unshift(lib) if File.directory?(lib) && !$LOAD_PATH.include?(lib)
 
 require 'pt'


### PR DESCRIPTION
$LOADPATH shenanigans are preventing bin/pt from running directly from a repo both a) under Ruby 1.9 and b) from a symlink.
