### PR TITLE
Add new method to show many stories together and condensed

### DIFF
--- a/lib/pt/ui.rb
+++ b/lib/pt/ui.rb
@@ -256,6 +256,7 @@ class PT::UI
     result = show_task(task)
   end
 
+  # takes a comma separated list of ids and prints the collection of tasks
   def show_condensed
     title("Tasks for #{user_s} in #{project_to_s}")
     if @params[0]


### PR DESCRIPTION
## Add a new method to show condensed stories - table list to list many tickets together.
### Useful for?

I'm a P.M. and I have github hooks working with P.T..

So i wrote a script to list tickets based on the SCM post commit  messages.
I will update this script to know the tickets that my team is been commiting.

https://www.pivotaltracker.com/help/api?version=v3#scm_post_commit_message_syntax 

It's very useful for scrum meetings. Now i have a easy way to write my scrum messages based on the git log 'hokked' messages + pivotal show condensed method.

``` ruby
#!/usr/bin/env ruby
require 'date'
require 'pp'
stories = []
`git log  --author frederico --no-merges --oneline  --since '#{Date.today - 1 } 00:00:00' --until '#{Date.today - 1} 23:59:59'`.each_line do |line|
  story_match = /\[.*\#(\d+)\]/.match(line)
  unless story_match.nil?
    stories << story_match[1]
  end
end

puts `pt show_condensed #{stories.uniq.join(',')}`

```
## Fixed the show method, it was not working here
