### PR TITLE
Fix in protected method "commands" for compatibility with Ruby 1.8

### DIFF
--- a/lib/pt/ui.rb
+++ b/lib/pt/ui.rb
@@ -431,7 +431,7 @@ class PT::UI
   protected
 
   def commands
-    (public_methods - Object.public_methods + [:help]).sort.map{ |c| c.to_sym}
+    (public_methods - Object.public_methods).map{ |c| c.to_sym}
   end
 
   # Config


### PR DESCRIPTION
In Ruby 1.9, public_methods return an array of symbols, but in 1.8 it returned an array of strings. This caused problems when adding the symbol :help and trying to sort the array (comparison between string and symbol).

Note that it's not necessary to add the "help" method because it is indeed a public method. Also, there's no need to have the commands sorted in the current use of the method (include?). So, my solution was to simplify the method to make it compatible with both ruby versions.
