### PR TITLE
Fixed `NoMethodError` on `pt list`.

### DIFF
--- a/lib/pt/data_row.rb
+++ b/lib/pt/data_row.rb
@@ -7,7 +7,9 @@ class PT::DataRow
   def initialize(orig, dataset)
     @record = orig
     @num = dataset.index(orig) + 1
-    @state = orig.current_state
+    if defined? orig.current_state
+      @state = orig.current_state
+    end
   end
 
   def method_missing(method)


### PR DESCRIPTION
When listing stories with `pt list` (not `pt show` as in commit comment, sorry) without the `all` argument a `NoMethodError` is thrown.

Trace when running `pt list`:

```
/usr/local/lib/ruby/gems/2.1.0/gems/pt-0.7.2/lib/pt/data_row.rb:10:in `initialize': undefined method `current_state' for #<PivotalTracker::Membership:0x007ff6931af310> (NoMethodError)
    from /usr/local/lib/ruby/gems/2.1.0/gems/pt-0.7.2/lib/pt/data_table.rb:10:in `new'
    from /usr/local/lib/ruby/gems/2.1.0/gems/pt-0.7.2/lib/pt/data_table.rb:10:in `block in initialize'
    from /usr/local/lib/ruby/gems/2.1.0/gems/pt-0.7.2/lib/pt/data_table.rb:10:in `map'
    from /usr/local/lib/ruby/gems/2.1.0/gems/pt-0.7.2/lib/pt/data_table.rb:10:in `initialize'
    from /usr/local/lib/ruby/gems/2.1.0/gems/pt-0.7.2/lib/pt/ui.rb:66:in `new'
    from /usr/local/lib/ruby/gems/2.1.0/gems/pt-0.7.2/lib/pt/ui.rb:66:in `list'
    from /usr/local/lib/ruby/gems/2.1.0/gems/pt-0.7.2/lib/pt/ui.rb:20:in `initialize'
    from /usr/local/Cellar/ruby/2.1.1/lib/ruby/gems/2.1.0/gems/pt-0.7.2/bin/pt:10:in `new'
    from /usr/local/Cellar/ruby/2.1.1/lib/ruby/gems/2.1.0/gems/pt-0.7.2/bin/pt:10:in `<top (required)>'
    from /usr/local/Cellar/ruby/2.1.1/bin/pt:23:in `load'
    from /usr/local/Cellar/ruby/2.1.1/bin/pt:23:in `<main>'
```

I'm not a Ruby hacker so the commit is more to point to the problem.

Running Ruby on OS X 10.9.2: `ruby --version` ⟶ `ruby 2.1.1p76 (2014-02-24 revision 45161) [x86_64-darwin13.0]`
