### PR TITLE
Fix error when looping over comments

### DIFF
--- a/lib/pt/ui.rb
+++ b/lib/pt/ui.rb
@@ -694,7 +694,9 @@ module PT
 
     task.comments.each do |n|
       title('========================================='.red)
-      message ">> #{n.person.initials}: #{n.text} [#{n.file_attachment_ids&.size}F]"
+      text = ">> #{n.person.initials}: #{n.text}"
+      text << "[#{n.file_attachment_ids.size}F]" if n.file_attachment_ids
+      message text
     end
     save_recent_task( task.id )
     end


### PR DESCRIPTION
This would cause PT to blow up when starting up a new project. Also important to note: while testing this it appeared to always return `0` as the size. I'm not sure if this was just my test project or Pivotal's API but something to consider.