### PR TITLE
prevents from generating frozen string

### DIFF
--- a/lib/pt/data_row.rb
+++ b/lib/pt/data_row.rb
@@ -18,7 +18,7 @@ module PT
     end
 
     def method_missing(method)
-      str = @record.send(method).to_s
+      str = "#{@record.send(method)}"
       str.respond_to?(:force_encoding) ? str.force_encoding('utf-8') : Iconv.iconv('UTF-8', 'UTF-8', str)
     end
 


### PR DESCRIPTION
fixes #80

According to ruby 2.7 [release documentation](https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/) `Module#name`, `true.to_s`, `false.to_s`, and `nil.to_s` now always return a frozen String. The returned String is always the same for a given object. This PR prevents generating a frozen string so that it can be modified later.
