### PR TITLE
Adds missing instance variable.

### DIFF
--- a/lib/pt/cli.rb
+++ b/lib/pt/cli.rb
@@ -19,6 +19,7 @@ module PT
       @global_config = load_global_config
       @local_config = load_local_config
       @client = Client.new(@global_config[:api_number], @local_config)
+      @params = args[1..-1]
       @project = @client.project
     end
 


### PR DESCRIPTION
fixes #73 
`@params` was used in many places but it was not initialized so, I checked the previous [tag](https://github.com/raul/pt/blob/v1.0.2/lib/ptt/ui.rb#L20) and added this line here.